### PR TITLE
Added authentication

### DIFF
--- a/authentication/index.js
+++ b/authentication/index.js
@@ -1,0 +1,109 @@
+const md5 = require('md5')
+const jwt = require('jsonwebtoken')
+const fs = require('fs')
+const basicAuth = require('basic-auth')
+const config = require.main.require('./config/index.js').get
+
+const USERS_FILE = "config/users.json"
+
+let users = []
+const authenticated = []
+
+function filter(req, res, next) {
+    function unauthorized(res) {
+        res.set('WWW-Authenticate', 'Basic realm=Authorization Required');
+        return res.sendStatus(401);
+    };
+  
+    var user = basicAuth(req);
+    if (isUserValid(user.name, user.pass)) {
+        next()
+    } else {
+        return unauthorized(res)
+    }
+}
+
+function isUserValid(user, pass) {
+    if (!user || !pass || user.length == 0 || pass.length == 0) {
+        return null
+    }
+    pass = md5(pass + config.auth.static_salt).toUpperCase()
+    if (users.length <= 0) {
+        if (!loadUsers()) {
+            return null
+        }
+    }
+    for (let i = 0; i < users.length; i++) {
+        if (users[i].username == user && users[i].password == pass) {
+            return users[i]
+        }
+    }
+    return null
+}
+
+function authenticate(username, pass) {
+    const user = isUserValid(username, pass)
+    if (user) {
+        var token = jwt.sign(user, config.auth.jwtSecret)
+        authenticated.push({
+            id: user.id,
+            token: token.trim()
+        })
+        return {token: token.trim() }
+    }
+    return null
+}
+
+function getTokenId(token) {
+    for (let i = 0; i < authenticated.length; i++) {
+        if (authenticated[i].token == token) {
+            return authenticated[i].id
+        }
+    }
+    return null
+}
+
+function verifyIO(socket, next) {
+    let token = socket.handshake.query.token
+    if (!token) {
+        next(new Error('No token supplied'))
+    } else {
+        jwt.verify(token, config.auth.jwtSecret, function(err, decoded) {
+            if (err) {
+                next(new Error('Token not valid'))
+            } else if (getTokenId(token) != null) {
+                next()
+            } else {
+                next(new Error('Token not found'))
+            }
+        });
+    }
+}
+
+function verifyToken(token) {
+    try {
+        jwt.verify(token, config.auth.jwtSecret)
+    } catch (err) {
+        return false
+    }
+    return getTokenId(token) != null
+}
+
+function loadUsers() {
+    try {
+        users = JSON.parse(fs.readFileSync(USERS_FILE))
+    } catch (err) {
+        // Ignore and use the default name.
+        console.log("Failed to load users file.")
+        console.log(err)
+        return false
+    }
+    return true
+}
+
+module.exports = {
+  authenticate,
+  verifyIO,
+  verifyToken,
+  filter
+}

--- a/config/index.js
+++ b/config/index.js
@@ -3,7 +3,11 @@ const config = {
     wolframalpha: {key: 'U7L4VR-K3WJPLK6Y2'},
     newsapi: {key: 'f4504df34ba9432f80ff040a41736518'},
     port: 4567,
-    zap: {ip: '192.168.178.172'}
+    zap: {ip: '192.168.178.172'},
+    auth: {
+        jwtSecret: 'random_secret_key',
+        static_salt: '_pbrain_auth'
+    }
 }
 
 module.exports = {

--- a/config/users.json
+++ b/config/users.json
@@ -1,0 +1,7 @@
+[
+  {
+    "id": 0,
+    "username": "demo",
+    "password": "8CB95357E5A4128B282576CE01B0B48F"
+  }
+]

--- a/password.js
+++ b/password.js
@@ -1,0 +1,7 @@
+const md5 = require('md5')
+const config = require('./config').get
+if (process.argv.length != 3) {
+    console.log("Usage: password.js <password>")
+} else {
+    console.log(md5(process.argv[2] + config.auth.static_salt).toUpperCase())
+}

--- a/src/index.html
+++ b/src/index.html
@@ -68,35 +68,119 @@
         }
     </script>
     <script>
-        var socket = io();
-        push_response('Just a second...');
-        socket.on('set_name', function(msg) {
-            var name = msg.name;
-
-            if (!name){
-                name = "Brain";
-            }   
-
-            $(".loading").remove();
-
-            if (annyang) {
-                var commands = {};
-                commands[name + " *tag"] = log_speech;
-                commands["(hey) " + name + " *tag"] = log_speech;
-                commands["(okay) " + name + " *tag"] = log_speech;
-                commands[name] = observe_speech;
-
-                
-                annyang.addCommands(commands);
-                SpeechKITT.setInstructionsText('Say "' + name + '" followed by…');
-                SpeechKITT.setSampleCommands(["What's the time", "Play Rumors by Fleetwood Mac"]);
+        function setupSocket(token) {
+            var socket = io.connect('/', {query: 'token=' + token});
+            push_response('Just a second...');
+            socket.on('set_name', function(msg) {
+                var name = msg.name;
+    
+                if (!name){
+                    name = "Brain";
+                }   
+    
+                $(".loading").remove();
+    
+                if (annyang) {
+                    var commands = {};
+                    commands[name + " *tag"] = log_speech;
+                    commands["(hey) " + name + " *tag"] = log_speech;
+                    commands["(okay) " + name + " *tag"] = log_speech;
+                    commands[name] = observe_speech;
+    
+                    
+                    annyang.addCommands(commands);
+                    SpeechKITT.setInstructionsText('Say "' + name + '" followed by…');
+                    SpeechKITT.setSampleCommands(["What's the time", "Play Rumors by Fleetwood Mac"]);
+                }
+            });
+    
+            socket.on('response', function(msg) {
+                $(".loading").remove();
+                response_handler(msg);
+            });
+        }
+    </script>
+    
+    <script>
+        function setCookie(cname, cvalue) {
+            var d = new Date();
+            d.setTime(d.getTime() + (365 * 24 * 60 * 60 * 1000));
+            var expires = "expires="+ d.toUTCString();
+            document.cookie = cname + "=" + cvalue + ";" + expires + ";path=/";
+        }
+        
+        function getCookie(cname) {
+            var name = cname + "=";
+            var decodedCookie = decodeURIComponent(document.cookie);
+            var ca = decodedCookie.split(';');
+            for(var i = 0; i <ca.length; i++) {
+                var c = ca[i];
+                while (c.charAt(0) == ' ') {
+                    c = c.substring(1);
+                }
+                if (c.indexOf(name) == 0) {
+                    return c.substring(name.length, c.length);
+                }
             }
-        });
-
-        socket.on('response', function(msg) {
-            $(".loading").remove();
-            response_handler(msg);
-        });
+            return null;
+        }
+    </script>
+    
+    <script>
+        function login(username, password, callback) {
+            var xhr = new XMLHttpRequest();
+            xhr.onreadystatechange = function() {
+                if (xhr.readyState == XMLHttpRequest.DONE) {
+                    if (xhr.status == 200) {
+                        callback(null, JSON.parse(xhr.responseText).token);
+                    } else {
+                        callback(xhr.responseText, null);
+                    }
+                }
+            }
+            xhr.open('GET', '/api/login', true);
+            xhr.setRequestHeader("Authorization", "Basic " + btoa("demo:demo"));
+            xhr.send();
+        }
+        function validate(token, callback) {
+            var xhr = new XMLHttpRequest();
+            xhr.onreadystatechange = function() {
+                if (xhr.readyState == XMLHttpRequest.DONE) {
+                    if (xhr.status == 200) {
+                        callback(null);
+                    } else {
+                        callback(xhr.responseText);
+                    }
+                }
+            }
+            xhr.open('GET', '/api/validate?token=' + token, true);
+            xhr.send();
+        }
+        
+        function presentLogin() {
+            var username = prompt("Enter username", "demo");
+            var password = prompt("Enter password", "demo");
+            login(username, password, function (err, token) {
+                if (!err) {
+                    setCookie("token", token);
+                    setupSocket(token);
+                } else {
+                    presentLogin();
+                }
+            });
+        }
+        
+        if (getCookie("token")) {
+            validate(getCookie("token"), function (err) {
+                if (err) {
+                    presentLogin();
+                } else {
+                    setupSocket(getCookie("token"));
+                }
+            });
+        } else {
+            presentLogin();
+        }
     </script>
 
 </body>

--- a/src/index.html
+++ b/src/index.html
@@ -68,8 +68,9 @@
         }
     </script>
     <script>
+        var socket = null;
         function setupSocket(token) {
-            var socket = io.connect('/', {query: 'token=' + token});
+            socket = io.connect('/', {query: 'token=' + token});
             push_response('Just a second...');
             socket.on('set_name', function(msg) {
                 var name = msg.name;


### PR DESCRIPTION
Hi Patrick,

Here's a first pass of doing authentication with tokens. I haven't figured out an elegant way to turn it off, so it's always on. There's a default user with the username demo and password demo. There's also a script called password.js to generate passwords in the format required for config/users.json.

I don't think we should merge this into master until we find a way for the demo to work without prompting when a user first downloads it, that and we'll both have to update the various apps first. Additionally, tokens do not currently persist across server reboots.

New API's:
/api/validate?token=<token> - returns HTTP status 200 if a token is valid.
/api/login - Required HTTP basic auth username and password, returns {token: "<token"} and status code 200 on success. This also creates a new token which persists until server start.

The socket.io handshake should be done with a token parameter ?token=<token>.

The flow when authenticating should be:
- If you have no stored token, then login.
- If you have a token, attempt to validate it.
- If valid, setup Socket.IO if not valid, login.