### PR TITLE
Adds promiscuous mode

### DIFF
--- a/server.js
+++ b/server.js
@@ -78,12 +78,8 @@ function * initialSetup() {
     if (!port) {
         console.log('Setting default values in database')
         yield global.db.setGlobalValue('port', 4567)
-        const user = {
-            username: 'demo',
-            password: yield authenticator.encryptPassword('demo'),
-            is_admin: true
-        }
-        yield global.db.saveUser(user)
+        yield global.db.setGlobalValue('promiscuous_mode', true)
+        yield global.db.setGlobalValue('promiscuous_admins', true)
     }
 }
 


### PR DESCRIPTION
Hi Pat,

I wanted to run this by you mainly because of the default settings. I've removed the creation of the demo user and replaced it by having promiscuous mode enabled by default, and by default that those promiscuously created users are admins. When setting up the server make sure to set promiscuous_admins to false.

Changelist:
- Added promiscuous_mode. If a user does not authenticate correctly, and the user does not exist then the user can be created if the setting is set to true.
- Changed default to not create a demo user. It now enables promiscuous mode and promiscuous admins.