### PR TITLE
Database improvements, better HTTP API's, settings page

### DIFF
--- a/api/settings.js
+++ b/api/settings.js
@@ -32,19 +32,20 @@ router.get('/skill_setting/:skill?/:name?', wrap(function *(req, res) {
 }))
 
 router.get('/user_setting/:user?/:skill?/:name?', wrap(function *(req, res) {
-    const user = req.user
-    if (user.is_admin || user.username == req.params.user) {
-        const url_user = yield global.db.getUserFromName(req.params.user)
-        if (req.params.user && req.params.skill && req.params.name && req.query.value) {
-            const value = JSON.parse(req.query.value)
-            yield global.db.setValue(req.params.skill, url_user, req.params.name, value)
-            res.json(value)
+    let user = req.user
+    if (req.params.user) {
+        if (user.is_admin || req.params.user == user.username) {
+            user = yield global.db.getUserFromName(req.params.user)
+            if (req.params.user && req.params.skill && req.params.name && req.query.value) {
+                const value = JSON.parse(req.query.value)
+                yield global.db.setValue(req.params.skill, user, req.params.name, value)
+                return res.json(value)
+            }
         } else {
-            res.json(yield global.db.getValue(req.params.skill, url_user, req.params.name))
+            return res.sendStatus(401)
         }
-    } else {
-        res.sendStatus(401)
     }
+    return res.json(yield global.db.getValue(req.params.skill, user, req.params.name))
 }))
 
 module.exports = router

--- a/api/settings.js
+++ b/api/settings.js
@@ -8,6 +8,9 @@ router.get('/global_setting/:key?', wrap(function *(req, res) {
             const value = JSON.parse(req.query.value)
             yield global.db.setGlobalValue(req.params.key, value)
             res.json(value)
+        } else if (req.params.key && (req.query.delete != undefined)) {
+            yield global.db.deleteGlobalValue(req.params.key)
+            res.json({text: "Successfully deleted."})
         } else {
             res.json(yield global.db.getGlobalValue(req.params.key))
         }
@@ -23,6 +26,9 @@ router.get('/skill_setting/:skill?/:name?', wrap(function *(req, res) {
             const value = JSON.parse(req.query.value)
             yield global.db.setSkillValue(req.params.skill, req.params.name, value)
             res.json(value)
+        } else if (req.params.skill && req.params.name && (req.query.delete != undefined)) {
+            yield global.db.deleteSkillValue(req.params.skill, req.params.name)
+            res.json({text: "Successfully deleted."})
         } else {
             res.json(yield global.db.getSkillValue(req.params.skill, req.params.name))
         }
@@ -36,16 +42,27 @@ router.get('/user_setting/:user?/:skill?/:name?', wrap(function *(req, res) {
     if (req.params.user) {
         if (user.is_admin || req.params.user == user.username) {
             user = yield global.db.getUserFromName(req.params.user)
-            if (req.params.user && req.params.skill && req.params.name && req.query.value) {
-                const value = JSON.parse(req.query.value)
-                yield global.db.setValue(req.params.skill, user, req.params.name, value)
-                return res.json(value)
+            if (user) {
+                if (req.params.user && req.params.skill && req.params.name && req.query.value) {
+                    const value = JSON.parse(req.query.value)
+                    yield global.db.setValue(req.params.skill, user, req.params.name, value)
+                    return res.json(value)
+                } else if (req.params.user && req.params.skill && req.params.name && (req.query.delete != undefined)) {
+                    yield global.db.deleteValue(req.params.skill, user, req.params.name)
+                    res.json({text: "Successfully deleted."})
+                }
+            } else {
+                return res.status(404).json({error: 'User not found.'})
             }
         } else {
             return res.sendStatus(401)
         }
     }
-    return res.json(yield global.db.getValue(req.params.skill, user, req.params.name))
+    if (user) {
+        return res.json(yield global.db.getValue(req.params.skill, user, req.params.name))
+    } else {
+        return res.status(404).json({error: 'User not found.'})
+    }
 }))
 
 module.exports = router

--- a/api/users.js
+++ b/api/users.js
@@ -7,7 +7,63 @@ router.get('/', wrap(function *(req, res) {
         const users = yield global.db.getUsers()
         res.json(users)
     } else {
-        res.sendStatus(401)
+        res.sendStatus(401).json({error: 'Forbidden.'})
+    }
+}))
+
+router.get('/:user/:delete?', wrap(function *(req, res) {
+    if (req.user.is_admin || req.params.user == req.user.username) {
+        const target_user = yield global.db.getUser({username: req.params.user})
+        if (target_user) {
+            if (req.params.delete) {
+                // This branch is for deleting an existing user.
+                yield global.db.deleteUser(target_user)
+                res.json({text: 'User deleted.'})
+            } else {
+                // This branch is for updating or fetching an existing user.
+                if (req.query.username || req.query.password || req.query.is_admin) {
+                    if (req.query.username) {
+                        target_user.username = req.query.username
+                    }
+                    if (req.query.password) {
+                        target_user.password = yield global.auth.encryptPassword(req.query.password)
+                    }
+                    if (req.user.is_admin && req.query.is_admin !== undefined && req.query.is_admin !== null) {
+                        target_user.is_admin = req.query.is_admin === true || req.query.is_admin == 'true'
+                    }
+                    console.log("Updating user.")
+                    try {
+                        console.log(target_user)
+                        yield global.db.saveUser(target_user);
+                        res.json(yield global.db.getUser({username: target_user.username}))
+                    } catch (err) {
+                        res.status(503).json({error: `Failed to add user ${JSON.stringify(err)}`})
+                    }
+                } else {
+                    res.json(target_user)
+                }
+            }
+        } else {
+            if (req.user.is_admin && req.query.password && req.query.is_admin) {
+                console.log("Adding new user");
+                const target_user = {
+                    username: req.params.username,
+                    password: yield global.auth.encryptPassword(req.query.password),
+                    is_admin: req.query.is_admin === true || req.query.is_admin == 'true'
+                }
+                try {
+                    console.log(target_user)
+                    yield global.db.saveUser(target_user);
+                    res.json(yield global.db.getUser({username: target_user.username}))
+                } catch (err) {
+                    res.status(503).json({error: `Failed to add user ${JSON.stringify(err)}`})
+                }
+            } else {
+                res.status(404).json({error: 'Target user not found.'})
+            }
+        }
+    } else {
+        res.sendStatus(401).json({error: 'Forbidden.'})
     }
 }))
 

--- a/api/users.js
+++ b/api/users.js
@@ -2,12 +2,12 @@ const wrap = require('co-express')
 const router = require('express').Router()
 
 router.get('/', wrap(function *(req, res) {
-    const user = req.user
-    if (user.is_admin) {
+    // If the user is an admin, return all users. If they're not, only return them.
+    if (req.user.is_admin) {
         const users = yield global.db.getUsers()
         res.json(users)
     } else {
-        res.sendStatus(401).json({error: 'Forbidden.'})
+        res.json([req.user])
     }
 }))
 

--- a/api/users.js
+++ b/api/users.js
@@ -1,0 +1,14 @@
+const wrap = require('co-express')
+const router = require('express').Router()
+
+router.get('/', wrap(function *(req, res) {
+    const user = req.user
+    if (user.is_admin) {
+        const users = yield global.db.getUsers()
+        res.json(users)
+    } else {
+        res.sendStatus(401)
+    }
+}))
+
+module.exports = router

--- a/api/users.js
+++ b/api/users.js
@@ -44,6 +44,7 @@ router.get('/:user/:delete?', wrap(function *(req, res) {
                 }
             }
         } else {
+            // This branch is for creating a new user.
             if (req.user.is_admin && req.query.password && req.query.is_admin) {
                 console.log("Adding new user");
                 const target_user = {
@@ -59,7 +60,7 @@ router.get('/:user/:delete?', wrap(function *(req, res) {
                     res.status(503).json({error: `Failed to add user ${JSON.stringify(err)}`})
                 }
             } else {
-                res.status(404).json({error: 'Target user not found.'})
+                res.status(404).json({error: 'Not enough parameters supplied or you\'re not an admin.'})
             }
         }
     } else {

--- a/api/users.js
+++ b/api/users.js
@@ -48,7 +48,7 @@ router.get('/:user/:delete?', wrap(function *(req, res) {
             if (req.user.is_admin && req.query.password && req.query.is_admin) {
                 console.log("Adding new user");
                 const target_user = {
-                    username: req.params.username,
+                    username: req.params.user,
                     password: yield global.auth.encryptPassword(req.query.password),
                     is_admin: req.query.is_admin === true || req.query.is_admin == 'true'
                 }

--- a/authentication/index.js
+++ b/authentication/index.js
@@ -55,7 +55,7 @@ function filter(newToken) {
             if (basicUser && basicUser.name && basicUser.pass) {
                 const encryptedPass = yield encryptPassword(basicUser.pass)
                 const user = yield global.db.getUser(basicUser.name, encryptedPass)
-                const hasUser = (yield global.db.getUserFromName(basicUser.name)) ? true : false
+                const hasUser = !!(yield global.db.getUserFromName(basicUser.name))
                 const promiscuousMode = yield global.db.getGlobalValue('promiscuous_mode')
                 if (user) {
                     if (newToken === true) {
@@ -75,7 +75,7 @@ function filter(newToken) {
                     const new_user = {
                         username: basicUser.name,
                         password: encryptedPass,
-                        is_admin: promiscuousAdmins ? true : false
+                        is_admin: !!promiscuousAdmins
                     }
                     console.log(`Creating promiscuous user ${new_user.username}.`)
                     yield global.db.saveUser(new_user)

--- a/authentication/index.js
+++ b/authentication/index.js
@@ -54,8 +54,8 @@ function filter(newToken) {
             const basicUser = basicAuth(req)
             if (basicUser && basicUser.name && basicUser.pass) {
                 const encryptedPass = yield encryptPassword(basicUser.pass)
-                const user = yield global.db.getUser(basicUser.name, encryptedPass)
-                const hasUser = !!(yield global.db.getUserFromName(basicUser.name))
+                const user = yield global.db.getUser({username: basicUser.name, password: encryptedPass})
+                const hasUser = !!(yield global.db.getUser({username: basicUser.name}))
                 const promiscuousMode = yield global.db.getGlobalValue('promiscuous_mode')
                 if (user) {
                     if (newToken === true) {
@@ -103,7 +103,7 @@ function login(req, res) {
 function logout(req, res) {
     co(function * () {
         if (req.params.user) {
-            const url_user = yield global.db.getUserFromName(req.params.user)
+            const url_user = yield global.db.getUser({username: req.params.user})
             if (url_user) {
                 if (req.user.is_admin || req.user.user_id == url_user.user_id) {
                     yield global.db.deleteUserTokens(url_user)
@@ -129,7 +129,7 @@ function logout(req, res) {
 function viewTokens(req, res) {
     co(function * () {
         if (req.params.user) {
-            const url_user = yield global.db.getUserFromName(req.params.user)
+            const url_user = yield global.db.getUser({username: req.params.user})
             if (url_user) {
                 if (req.user.is_admin || req.user.user_id == url_user.user_id) {
                     res.json(yield global.db.getUserTokens(url_user))

--- a/server.js
+++ b/server.js
@@ -110,6 +110,17 @@ co(function * () {
     http.listen(port, () => {
         console.log(`Server started on http://localhost:${port}`)
     })
+
+    const promiscuous = yield global.db.getGlobalValue('promiscuous_mode')
+    const promiscuous_admins = yield global.db.getGlobalValue('promiscuous_admins')
+    if (promiscuous) {
+        console.log('Warning! Promiscuous mode is enabled all logins will succeed.')
+        if (promiscuous_admins) {
+            console.log('Possibly deadly warning! Promiscuous admins is enabled.' +
+                ' All new users will be admins and can view each others data.')
+        }
+        console.log(`Settings can be changed at http://localhost:${port}/settings.html`)
+    }
 }).catch(err => {
     console.log(err)
     throw err

--- a/server.js
+++ b/server.js
@@ -33,7 +33,7 @@ app.use(cookieParser())
 app.use('/', [global.auth.filter(true), express.static('./src')])
 app.use('/api/settings', [global.auth.filter(false), settingsApi])
 app.use('/api/users', [global.auth.filter(false), usersApi])
-app.get('/me', global.auth.filter(false), wrap(function * (req, res) {
+app.get('/api/me', global.auth.filter(false), wrap(function * (req, res) {
     res.json(req.user)
 }))
 

--- a/server.js
+++ b/server.js
@@ -33,8 +33,11 @@ app.use(cookieParser())
 app.use('/', [global.auth.filter(true), express.static('./src')])
 app.use('/api/settings', [global.auth.filter(false), settingsApi])
 app.use('/api/users', [global.auth.filter(false), usersApi])
-app.get('/api/me', global.auth.filter(false), wrap(function * (req, res) {
+app.get('/api/user', global.auth.filter(false), wrap(function * (req, res) {
     res.json(req.user)
+}))
+app.get('/api/token', global.auth.filter(false), wrap(function * (req, res) {
+    res.json(req.token)
 }))
 
 // TODO parse services in query

--- a/server.js
+++ b/server.js
@@ -11,6 +11,7 @@ const search = require('./api/core-ask.js')
 const skills = require('./skills/skills.js')
 const authenticator = require('./authentication')
 const settingsApi = require('./api/settings.js')
+const usersApi = require('./api/users.js')
 const cookieParser = require('cookie-parser')
 global.db = require('./sqlite_db')
 
@@ -31,6 +32,7 @@ app.use(cookieParser())
 
 app.use('/', [authenticator.filter(true), express.static('./src')])
 app.use('/api/settings', [authenticator.filter(false), settingsApi])
+app.use('/api/users', [authenticator.filter(false), usersApi])
 
 // TODO parse services in query
 app.get('/api/ask', authenticator.filter(false), wrap(function * (req, res) {

--- a/sqlite_db/index.js
+++ b/sqlite_db/index.js
@@ -214,6 +214,7 @@ function * getValue(skill, user, key) {
     const base = 'SELECT skill, users.username, key, value FROM user_settings INNER JOIN users ON users.user_id = user_settings.user_id'
     let user_id = (user) ? user.user_id : undefined
     const query = makeConditionalQuery(base, ['skill = ?', 'user_settings.user_id = ?', 'key = ?'], [skill, user_id, key])
+    query.query += ' ORDER BY skill ASC, users.username ASC, key ASC'
     return yield allQueryWrapper(query.query, query.values, key)
 }
 
@@ -233,6 +234,7 @@ function * setSkillValue(skill, key, value) {
 function * getSkillValue(skill, key) {
     const base = 'SELECT skill, key, value FROM skill_settings'
     const query = makeConditionalQuery(base, ['skill = ?', 'key = ?'], [skill, key])
+    query.query += ' ORDER BY skill ASC, key ASC'
     return yield allQueryWrapper(query.query, query.values, key)
 }
 
@@ -252,6 +254,7 @@ function * setGlobalValue(key, value) {
 function * getGlobalValue(key) {
     const base = 'SELECT key, value FROM global_settings'
     const query = makeConditionalQuery(base, ['key = ?'], [key])
+    query.query += ' ORDER BY key ASC'
     return yield allQueryWrapper(query.query, query.values, key)
 }
 

--- a/sqlite_db/index.js
+++ b/sqlite_db/index.js
@@ -168,6 +168,18 @@ function * setValue(skill, user, key, value) {
     })
 }
 
+function * deleteValue(skill, user, key) {
+    return new Promise((resolve, reject) => {
+        db.get('DELETE FROM user_settings WHERE skill = ? AND user_id = ? AND key = ?', skill, user.user_id, key, (err, row) => {
+            if (err) {
+                reject(err)
+            } else {
+                resolve()
+            }
+        })
+    })
+}
+
 function makeConditionalQuery(query, conditions, values) {
     const endConditions = []
     const endValues = []
@@ -238,6 +250,18 @@ function * getSkillValue(skill, key) {
     return yield allQueryWrapper(query.query, query.values, key)
 }
 
+function * deleteSkillValue(skill, key) {
+    return new Promise((resolve, reject) => {
+        db.get('DELETE FROM skill_settings WHERE skill = ? AND key = ?', skill, key, (err, row) => {
+            if (err) {
+                reject(err)
+            } else {
+                resolve()
+            }
+        })
+    })
+}
+
 function * setGlobalValue(key, value) {
     value = JSON.stringify(value)
     return new Promise((resolve, reject) => {
@@ -256,6 +280,18 @@ function * getGlobalValue(key) {
     const query = makeConditionalQuery(base, ['key = ?'], [key])
     query.query += ' ORDER BY key ASC'
     return yield allQueryWrapper(query.query, query.values, key)
+}
+
+function * deleteGlobalValue(key) {
+    return new Promise((resolve, reject) => {
+        db.get('DELETE FROM global_settings WHERE key = ?', key, (err, row) => {
+            if (err) {
+                reject(err)
+            } else {
+                resolve()
+            }
+        })
+    })
 }
 
 function * saveToken(user, token) {
@@ -375,10 +411,13 @@ module.exports = {
     setup,
     setValue,
     getValue,
+    deleteValue,
     setSkillValue,
     getSkillValue,
+    deleteSkillValue,
     setGlobalValue,
     getGlobalValue,
+    deleteGlobalValue,
     saveToken,
     deleteToken,
     deleteUserTokens,

--- a/sqlite_db/index.js
+++ b/sqlite_db/index.js
@@ -121,7 +121,7 @@ function * setup(database) {
 }
 
 function * getUserFromName(username) {
-    const user = yield queryWrapper(db.get, 'SELECT * FROM users WHERE username = ?', [username])
+    const user = yield queryWrapper(db.get, 'SELECT user_id, username, is_admin FROM users WHERE username = ?', [username])
     if (user) {
         user.is_admin = user.is_admin == 1
     }
@@ -139,7 +139,7 @@ function * saveUser(user) {
 }
 
 function * getUser(username, password) {
-    const user = yield queryWrapper(db.get, 'SELECT * FROM users WHERE username = ? AND password = ?', [username, password])
+    const user = yield queryWrapper(db.get, 'SELECT user_id, username, is_admin FROM users WHERE username = ? AND password = ?', [username, password])
     if (user) {
         user.is_admin = user.is_admin == 1
     }
@@ -216,7 +216,7 @@ function * getUserFromToken(token) {
     if (token.token) {
         token = token.token
     }
-    const user = yield queryWrapper(db.get, 'SELECT users.* FROM users INNER JOIN tokens ON tokens.user_id=users.user_id WHERE tokens.token = ?', [token])
+    const user = yield queryWrapper(db.get, 'SELECT users.user_id, users.username, users.is_admin FROM users INNER JOIN tokens ON tokens.user_id=users.user_id WHERE tokens.token = ?', [token])
     if (user) {
         user.is_admin = user.is_admin == 1
     }

--- a/sqlite_db/index.js
+++ b/sqlite_db/index.js
@@ -13,168 +13,18 @@ const setupQuery =
     'CREATE TABLE IF NOT EXISTS user_settings(user_id INTEGER REFERENCES users(user_id), skill TEXT NOT NULL, key TEXT NOT NULL, value TEXT, PRIMARY KEY(user_id, skill, key));' +
     'CREATE TABLE IF NOT EXISTS version(version INTEGER);'
 
-function * getVersion() {
+function * queryWrapper(fn, query, values) {
+    if (values) {
+        fn = fn.bind(db, query, values)
+    } else {
+        fn = fn.bind(db, query)
+    }
     return new Promise((resolve, reject) => {
-        db.get('SELECT * FROM version LIMIT 1', (err, row) => {
+        fn((err, rows) => {
             if (err) {
-                reject(err)
+                reject(new Error(`Error running query: ${query} - ${JSON.stringify(values)}: ${err}`))
             } else {
-                if (row) {
-                    resolve(row.version)
-                } else {
-                    resolve(0)
-                }
-            }
-        })
-    })
-}
-
-function * setVersion(version) {
-    return new Promise((resolve, reject) => {
-        db.get('INSERT OR REPLACE INTO version(version) VALUES (?)', version, (err, row) => {
-            if (err) {
-                reject(err)
-            } else {
-                resolve()
-            }
-        })
-    })
-}
-
-function * databaseV1Setup() {
-    return new Promise((resolve, reject) => {
-        db.run('ALTER TABLE users ADD is_admin INTEGER DEFAULT 0', (err) => {
-            if (err) {
-                reject(err)
-            } else {
-                resolve()
-            }
-        })
-    })
-}
-
-function * databaseV2Setup() {
-    const query = 'ALTER TABLE tokens ADD name TEXT DEFAULT NULL;' +
-            'ALTER TABLE queries ADD token TEXT REFERENCES tokens(token);'
-    return new Promise((resolve, reject) => {
-        db.exec(query, (err) => {
-            if (err) {
-                reject(err)
-            } else {
-                resolve()
-            }
-        })
-    })
-}
-
-function * setup(database) {
-    return new Promise((resolve, reject) => {
-        db = new sqlite3.cached.Database(database, err => {
-            if (err) {
-                console.log(`Failed to open database. ${err}`)
-                reject(err)
-            } else {
-                db.exec(setupQuery, err => {
-                    if (err) {
-                        reject(err)
-                    } else {
-                        co(function * () {
-                            const version = yield getVersion()
-                            switch(version) {
-                                case 0:
-                                    yield databaseV1Setup()
-                                    yield setVersion(1)
-                                    // Fallthrough.
-                                case 1:
-                                    yield databaseV2Setup()
-                                    yield setVersion(2)
-                                default: break
-                            }
-                        }).catch(err => {
-                            reject(err)
-                        })
-                        resolve()
-                    }
-                })
-            }
-        })
-    })
-}
-
-function * getUserFromName(username) {
-    return new Promise((resolve, reject) => {
-        db.get('SELECT * FROM users WHERE username = ?', username, (err, row) => {
-            if (err) {
-                reject(err)
-            } else {
-                if (row) {
-                    row.is_admin = row.is_admin == 1
-                }
-                resolve(row)
-            }
-        })
-    })
-}
-
-function * saveUser(user) {
-    const dbuser = yield getUserFromName(user.username)
-    const is_admin = (user.is_admin) ? user.is_admin : 0
-    return new Promise((resolve, reject) => {
-        if (dbuser) {
-            db.run('UPDATE users SET username=?,password=?,is_admin=? WHERE user_id=?', user.username, user.password, is_admin, dbuser.user_id, (err) => {
-                if (err) {
-                    reject(err)
-                } else {
-                    resolve()
-                }
-            })
-        } else {
-            db.run('INSERT INTO users(username, password, is_admin) VALUES(?, ?, ?)', user.username, user.password, is_admin, (err) => {
-                if (err) {
-                    reject(err)
-                } else {
-                    resolve()
-                }
-            })
-        }
-    })
-}
-
-function * getUser(username, password) {
-    return new Promise((resolve, reject) => {
-        db.get('SELECT * FROM users WHERE username = ? AND password = ?', username, password, (err, row) => {
-            if (err) {
-                reject(err)
-            } else {
-                if (row) {
-                    row.is_admin = row.is_admin == 1
-                }
-                resolve(row)
-            }
-        })
-    })
-}
-
-function * setValue(skill, user, key, value) {
-    value = JSON.stringify(value)
-    return new Promise((resolve, reject) => {
-        db.get('INSERT OR REPLACE INTO user_settings(skill, user_id, key, value) VALUES (?, ?, ?, ?)', skill, user.user_id, key, value, (err, row) => {
-            if (err) {
-                reject(err)
-            } else {
-                resolve()
-            }
-        })
-    })
-}
-
-function * deleteValue(skill, user, key) {
-    return new Promise((resolve, reject) => {
-        db.get('DELETE FROM user_settings WHERE skill = ? AND user_id = ? AND key = ?', skill, user.user_id, key, (err, row) => {
-            if (err) {
-                reject(err)
-            } else {
-                resolve()
+                resolve(rows);
             }
         })
     })
@@ -200,26 +50,100 @@ function makeConditionalQuery(query, conditions, values) {
 }
 
 function * allQueryWrapper(query, values, key) {
+    const rows = yield queryWrapper(db.all, query, values)
+    if (Array.isArray(rows) && rows.length > 0) {
+        rows.map((row) => {
+            row.value = JSON.parse(row.value)
+        })
+        if (key) {
+            return rows[0].value
+        } else {
+            return rows
+        }
+    }
+    return undefined
+}
+
+function * getVersion() {
+    const row = yield queryWrapper(db.get, 'SELECT * FROM version ORDER BY version DESC LIMIT 1')
+    return row.version
+}
+
+function * setVersion() {
+    yield queryWrapper(db.get, 'INSERT OR REPLACE INTO version(version) VALUES (?)', [version])
+}
+
+function * databaseV1Setup() {
+    yield queryWrapper(db.run, 'ALTER TABLE users ADD is_admin INTEGER DEFAULT 0')
+}
+
+function * databaseV2Setup() {
+    const query = 'ALTER TABLE tokens ADD name TEXT DEFAULT NULL;' +
+            'ALTER TABLE queries ADD token TEXT REFERENCES tokens(token);'
+    yield queryWrapper(db.exec, query)
+}
+
+function * createDb(database) {
     return new Promise((resolve, reject) => {
-        db.all(query, values, (err, rows) => {
+        const local_db = new sqlite3.cached.Database(database, err => {
             if (err) {
                 reject(err)
             } else {
-                if (Array.isArray(rows) && rows.length > 0) {
-                    rows.map((row) => {
-                        row.value = JSON.parse(row.value)
-                    })
-                    if (key) {
-                        resolve(rows[0].value)
-                    } else {
-                        resolve(rows)
-                    }
-                } else {
-                    resolve(undefined)
-                }
+                resolve(local_db)
             }
         })
     })
+}
+
+function * setup(database) {
+    db = yield createDb(database)
+    yield queryWrapper(db.exec, setupQuery)
+    const version = yield getVersion()
+    switch(version) {
+        case 0:
+            yield databaseV1Setup()
+            yield setVersion(1)
+            // Fallthrough.
+        case 1:
+            yield databaseV2Setup()
+            yield setVersion(2)
+        default: break
+    }
+}
+
+function * getUserFromName(username) {
+    const user = yield queryWrapper(db.get, 'SELECT * FROM users WHERE username = ?', [username])
+    if (user) {
+        user.is_admin = row.is_admin == 1
+    }
+    return user
+}
+
+function * saveUser(user) {
+    const dbuser = yield getUserFromName(user.username)
+    const is_admin = (user.is_admin) ? user.is_admin : 0
+    if (dbuser) {
+        yield queryWrapper(db.run, 'UPDATE users SET username=?,password=?,is_admin=? WHERE user_id=?', [user.username, user.password, is_admin, dbuser.user_id])
+    } else {
+        yield queryWrapper(db.run, 'INSERT INTO users(username, password, is_admin) VALUES(?, ?, ?)', [user.username, user.password, is_admin])
+    }
+}
+
+function * getUser(username, password) {
+    const user = yield queryWrapper(db.get, 'SELECT * FROM users WHERE username = ? AND password = ?', [username, password])
+    if (user) {
+        user.is_admin = row.is_admin == 1
+    }
+    return user
+}
+
+function * setValue(skill, user, key, value) {
+    value = JSON.stringify(value)
+    yield queryWrapper(db.run, 'INSERT OR REPLACE INTO user_settings(skill, user_id, key, value) VALUES (?, ?, ?, ?)', [skill, user.user_id, key, value])
+}
+
+function * deleteValue(skill, user, key) {
+    yield queryWrapper(db.run, 'DELETE FROM user_settings WHERE skill = ? AND user_id = ? AND key = ?', [skill, user.user_id, key])
 }
 
 function * getValue(skill, user, key) {
@@ -232,15 +156,7 @@ function * getValue(skill, user, key) {
 
 function * setSkillValue(skill, key, value) {
     value = JSON.stringify(value)
-    return new Promise((resolve, reject) => {
-        db.get('INSERT OR REPLACE INTO skill_settings(skill, key, value) VALUES (?, ?, ?)', skill, key, value, (err, row) => {
-            if (err) {
-                reject(err)
-            } else {
-                resolve()
-            }
-        })
-    })
+    yield queryWrapper(db.run, 'INSERT OR REPLACE INTO skill_settings(skill, key, value) VALUES (?, ?, ?)', [skill, key, value])
 }
 
 function * getSkillValue(skill, key) {
@@ -251,28 +167,12 @@ function * getSkillValue(skill, key) {
 }
 
 function * deleteSkillValue(skill, key) {
-    return new Promise((resolve, reject) => {
-        db.get('DELETE FROM skill_settings WHERE skill = ? AND key = ?', skill, key, (err, row) => {
-            if (err) {
-                reject(err)
-            } else {
-                resolve()
-            }
-        })
-    })
+    yield queryWrapper(db.run, 'DELETE FROM skill_settings WHERE skill = ? AND key = ?', [skill, key])
 }
 
 function * setGlobalValue(key, value) {
     value = JSON.stringify(value)
-    return new Promise((resolve, reject) => {
-        db.get('INSERT OR REPLACE INTO global_settings(key, value) VALUES (?, ?)', key, value, (err, row) => {
-            if (err) {
-                reject(err)
-            } else {
-                resolve()
-            }
-        })
-    })
+    yield queryWrapper(db.run, 'INSERT OR REPLACE INTO global_settings(key, value) VALUES (?, ?)', [key, value])
 }
 
 function * getGlobalValue(key) {
@@ -283,80 +183,35 @@ function * getGlobalValue(key) {
 }
 
 function * deleteGlobalValue(key) {
-    return new Promise((resolve, reject) => {
-        db.get('DELETE FROM global_settings WHERE key = ?', key, (err, row) => {
-            if (err) {
-                reject(err)
-            } else {
-                resolve()
-            }
-        })
-    })
+    yield queryWrapper(db.run, 'DELETE FROM global_settings WHERE key = ?', [key])
 }
 
 function * saveToken(user, token) {
     const dbtokens = yield getUserTokens(user, token)
-    return new Promise((resolve, reject) => {
-        if (dbtokens.length > 0) {
-            db.run('UPDATE tokens SET name=? WHERE user_id=? AND token=?', token.name, user.user_id, token.token, (err) => {
-                if (err) {
-                    reject(err)
-                } else {
-                    resolve()
-                }
-            })
-        } else {
-            db.run('INSERT INTO tokens(token, user_id, name) VALUES(?, ?, ?)', token.token, user.user_id, token.name, (err) => {
-                if (err) {
-                    reject(err)
-                } else {
-                    resolve()
-                }
-            })
-        }
-    })
+    if (dbtokens.length > 0) {
+        yield queryWrapper(db.run, 'UPDATE tokens SET name=? WHERE user_id=? AND token=?', [token.name, user.user_id, token.token])
+    } else {
+        yield queryWrapper(db.run, 'INSERT INTO tokens(token, user_id, name) VALUES(?, ?, ?)', [token.token, user.user_id, token.name])
+    }
 }
 
 function * deleteToken(token) {
-    return new Promise((resolve, reject) => {
-        db.get('DELETE FROM tokens WHERE token = ?', token.token, (err, row) => {
-            if (err) {
-                reject(err)
-            } else {
-                resolve()
-            }
-        })
-    })
+    yield queryWrapper(db.run, 'DELETE FROM tokens WHERE token = ?', [token.token])
 }
 
 function * deleteUserTokens(user) {
-    return new Promise((resolve, reject) => {
-        db.get('DELETE FROM tokens WHERE user_id = ?', user.user_id, (err, row) => {
-            if (err) {
-                reject(err)
-            } else {
-                resolve()
-            }
-        })
-    })
+    yield queryWrapper(db.run, 'DELETE FROM tokens WHERE user_id = ?', [user.user_id])
 }
 
 function * getUserFromToken(token) {
     if (token.token) {
         token = token.token
     }
-    return new Promise((resolve, reject) => {
-        db.get('SELECT users.* FROM users INNER JOIN tokens ON tokens.user_id=users.user_id WHERE tokens.token = ?', token, (err, row) => {
-            if (err) {
-                reject(err)
-            } else {
-                if (row) {
-                    row.is_admin = row.is_admin == 1
-                }
-                resolve(row)
-            }
-        })
-    })
+    const user = yield queryWrapper(db.get, 'SELECT users.* FROM users INNER JOIN tokens ON tokens.user_id=users.user_id WHERE tokens.token = ?', [token])
+    if (user) {
+        user.is_admin = user.is_admin == 1
+    }
+    return user
 }
 
 function * getUserTokens(user, token) {
@@ -366,45 +221,28 @@ function * getUserTokens(user, token) {
     }
     const base = 'SELECT token, timestamp, name FROM tokens'
     const query = makeConditionalQuery(base, ['user_id = ?', 'name = ?', 'token = ?'], [user.user_id, parsedToken.name, parsedToken.token])
-    return new Promise((resolve, reject) => {
-        db.all(query.query, query.values, (err, rows) => {
-            if (err) {
-                reject(err)
-            } else {
-                resolve(rows)
-            }
-        })
-    })
+    return yield queryWrapper(db.all, query.query, query.values)
 }
 
 function * addQuery(query, user, token) {
     if (token == null) {
         token = {token: null}
     }
+    query = JSON.stringify(query)
     return new Promise((resolve, reject) => {
-        query = JSON.stringify(query)
         db.run('INSERT INTO queries(query, user_id, token) VALUES(?, ?, ?)', query, user.user_id, token.token, function (err) {
             if (err) {
                 reject(err)
             } else {
-                // lastId +1 because row IDs start at 0 and SQL IDs start at 1.
-                resolve({query_id: this.lastId + 1, query, user})
+                resolve({query_id: this.lastID, query, user})
             }
         })
     })
 }
 
 function * addResponse(query, skill, response) {
-    return new Promise((resolve, reject) => {
-        response = JSON.stringify(response)
-        db.run('INSERT INTO responses(query_id, skill, response) VALUES(?, ?, ?)', query.query_id, skill, response, err => {
-            if (err) {
-                reject(err)
-            } else {
-                resolve()
-            }
-        })
-    })
+    response = JSON.stringify(response)
+    yield queryWrapper(db.run, 'INSERT INTO responses(query_id, skill, response) VALUES(?, ?, ?)', [query.query_id, skill, response])
 }
 
 module.exports = {

--- a/src/settings.html
+++ b/src/settings.html
@@ -75,6 +75,7 @@ server restart.
                 if (xhr.status == 200) {
                     callback(xhr.responseText);
                 } else {
+                    console.log(xhr.responseText);
                     callback(null);
                 }
             }
@@ -102,14 +103,17 @@ server restart.
     }
 
     function clearTable(table) {
-        const tBody = table.tBodies[0].cloneNode(false);
-        tBody.appendChild(table.rows[0]);
-        tBody.appendChild(table.rows[1]);
-        table.replaceChild(tBody, table.tBodies[0]);
+        var rows = table.rows;
+        var i = rows.length - 1;
+        while (i > 1) {
+          rows[i].parentNode.removeChild(rows[i]);
+          --i;
+        }   
     }
 
     function setupUserSettings() {
-        request('/api/settings/user_setting', function (data) {
+        const root = '/api/settings/user_setting';
+        request(root, function (data) {
             if (data) {
                 data = JSON.parse(data);
                 const table = document.getElementById("user_settings");
@@ -121,8 +125,27 @@ server restart.
                     user.innerHTML = setting.username;
                     const key = row.insertCell(2);
                     key.innerHTML = setting.key;
-                    setupUpdate(row.insertCell(3), row.insertCell(4), `/api/settings/user_setting/${setting.username}/${setting.skill}/${setting.key}`, setting.value, refreshUserSettings);
+                    setupUpdate(row.insertCell(3), row.insertCell(4), `${root}/${setting.username}/${setting.skill}/${setting.key}`, setting.value, refreshUserSettings);
                 });
+                const addUser = document.getElementById("add_user_add");
+                const skill = document.getElementById("add_user_skill");
+                const user = document.getElementById("add_user_user");
+                const key = document.getElementById("add_user_key");
+                const value = document.getElementById("add_user_value");
+                addUser.onclick = function() {
+                    const newValue = encodeURIComponent(JSON.stringify(parseValue(value.value)));
+                    const url = `${root}/${user.value}/${skill.value}/${key.value}?value=${newValue}`;
+                    addUser.disabled = true;
+                    request(url, function (data) {
+                        addUser.disabled = false;
+                        if (data) {
+                            skill.value = user.value = key.value = value.value = "";
+                            refreshUserSettings();
+                        } else {
+                            alert("Failed to add setting.");
+                        }
+                    });
+                };
             }
         });
     }
@@ -131,7 +154,8 @@ server restart.
         setupUserSettings();
     }
     function setupSkillSettings() {
-        request('/api/settings/skill_setting', function (data) {
+        const root = '/api/settings/skill_setting'
+        request(root, function (data) {
             if (data) {
                 data = JSON.parse(data);
                 const table = document.getElementById("skill_settings");
@@ -141,8 +165,26 @@ server restart.
                     skill.innerHTML = setting.skill;
                     const key = row.insertCell(1);
                     key.innerHTML = setting.key;
-                    setupUpdate(row.insertCell(2), row.insertCell(3), `/api/settings/skill_setting/${setting.skill}/${setting.key}`, setting.value, refreshSkillSettings);
+                    setupUpdate(row.insertCell(2), row.insertCell(3), `${root}/${setting.skill}/${setting.key}`, setting.value, refreshSkillSettings);
                 });
+                const addSkill = document.getElementById("add_skill_add");
+                const skill = document.getElementById("add_skill_skill");
+                const key = document.getElementById("add_skill_key");
+                const value = document.getElementById("add_skill_value");
+                addSkill.onclick = function() {
+                    const newValue = encodeURIComponent(JSON.stringify(parseValue(value.value)));
+                    const url = `${root}/${skill.value}/${key.value}?value=${newValue}`;
+                    addSkill.disabled = true;
+                    request(url, function (data) {
+                        addSkill.disabled = false;
+                        if (data) {
+                            skill.value = key.value = value.value = "";
+                            refreshSkillSettings();
+                        } else {
+                            alert("Failed to add setting.");
+                        }
+                    });
+                };
             } else {
                 document.getElementById("skill_settings_div").style.visibility = "hidden";
             }
@@ -153,7 +195,8 @@ server restart.
         setupSkillSettings();
     }
     function setupGlobalSettings() {
-        request('/api/settings/global_setting', function (data) {
+        const root = '/api/settings/global_setting';
+        request(root, function (data) {
             if (data) {
                 data = JSON.parse(data);
                 const table = document.getElementById("global_settings");
@@ -161,8 +204,25 @@ server restart.
                     const row = table.insertRow(-1);
                     const key = row.insertCell(0);
                     key.innerHTML = setting.key;
-                    setupUpdate(row.insertCell(1), row.insertCell(2), `/api/settings/global_setting/${setting.key}`, setting.value, refreshGlobalSettings);
+                    setupUpdate(row.insertCell(1), row.insertCell(2), `${root}/${setting.key}`, setting.value, refreshGlobalSettings);
                 });
+                const addGlobal = document.getElementById("add_global_add");
+                const key = document.getElementById("add_global_key");
+                const value = document.getElementById("add_global_value");
+                addGlobal.onclick = function() {
+                    const newValue = encodeURIComponent(JSON.stringify(parseValue(value.value)));
+                    const url = `${root}/${key.value}?value=${newValue}`;
+                    addGlobal.disabled = true;
+                    request(url, function (data) {
+                        addGlobal.disabled = false;
+                        if (data) {
+                            key.value = value.value = "";
+                            refreshGlobalSettings();
+                        } else {
+                            alert("Failed to add setting.");
+                        }
+                    });
+                };
             } else {
                 document.getElementById("global_settings_div").style.visibility = "hidden";
             }
@@ -196,7 +256,7 @@ server restart.
             if (confirm("Are you sure you want to delete this item?")) {
                 update.disabled = true;
                 remove.disabled = true;
-                request(`${url}/remove`, function (data) {
+                request(`${url}?delete`, function (data) {
                     update.disabled = false;
                     remove.disabled = false;
                     if (data) {

--- a/src/settings.html
+++ b/src/settings.html
@@ -3,32 +3,74 @@
 <head>
     <meta charset="UTF-8">
     <title>P-Brain Settings</title>
+    <style>
+        input {
+            width: 100%;
+            box-sizing: border-box;
+            -webkit-box-sizing: border-box;
+            -moz-box-sizing: border-box;
+        }
+    </style>
 </head>
 <body>
-    <h1>P-Brain Settings</h1>
-    Changing user settings tends to only require a client refresh. Changing skill and global settings tends to require a server restart.
-    <h2>User Settings</h2>
+<h1>P-Brain Settings</h1>
+Changing user settings tends to only require a client refresh. Changing skill and global settings tends to require a
+server restart.
+<h2>User Settings</h2>
+<div>
     <table id="user_settings" border="1">
         <tr>
-            <th>Skill</th><th>User</th><th>Key</th><th>Value</th>
+            <th>Skill</th>
+            <th>User</th>
+            <th>Key</th>
+            <th>Value</th>
+            <th>Action</th>
+        </tr>
+        <tr>
+            <td><input type="text" id="add_user_skill"/></td>
+            <td><input type="text" id="add_user_user"/></td>
+            <td><input type="text" id="add_user_key"/></td>
+            <td><input type="text" id="add_user_value"/></td>
+            <td><input type="submit" id="add_user_add" value="Add"/></td>
         </tr>
     </table>
+</div>
+<div id="skill_settings_div">
     <h2>Skill Settings</h2>
     <table id="skill_settings" border="1">
         <tr>
-            <th>Skill</th><th>Key</th><th>Value</th>
+            <th>Skill</th>
+            <th>Key</th>
+            <th>Value</th>
+            <th>Action</th>
+        </tr>
+        <tr>
+            <td><input type="text" id="add_skill_skill"/></td>
+            <td><input type="text" id="add_skill_key"/></td>
+            <td><input type="text" id="add_skill_value"/></td>
+            <td><input type="submit" id="add_skill_add" value="Add"/></td>
         </tr>
     </table>
+</div>
+<div id="global_settings_div">
     <h2>Global Settings</h2>
     <table id="global_settings" border="1">
         <tr>
-            <th>Key</th><th>Value</th>
+            <th>Key</th>
+            <th>Value</th>
+            <th>Action</th>
+        </tr>
+        <tr>
+            <td><input type="text" id="add_global_key"/></td>
+            <td><input type="text" id="add_global_value"/></td>
+            <td><input type="submit" id="add_global_add" value="Add"/></td>
         </tr>
     </table>
+</div>
 <script>
     function request(url, callback) {
         const xhr = new XMLHttpRequest();
-        xhr.onreadystatechange = function() {
+        xhr.onreadystatechange = function () {
             if (xhr.readyState == XMLHttpRequest.DONE) {
                 if (xhr.status == 200) {
                     callback(xhr.responseText);
@@ -59,88 +101,132 @@
         return value;
     }
 
-    function setupUpdate(element, url, value, length) {
+    function clearTable(table) {
+        const tBody = table.tBodies[0].cloneNode(false);
+        tBody.appendChild(table.rows[0]);
+        tBody.appendChild(table.rows[1]);
+        table.replaceChild(tBody, table.tBodies[0]);
+    }
+
+    function setupUserSettings() {
+        request('/api/settings/user_setting', function (data) {
+            if (data) {
+                data = JSON.parse(data);
+                const table = document.getElementById("user_settings");
+                data.map(function (setting) {
+                    const row = table.insertRow(-1);
+                    const skill = row.insertCell(0);
+                    skill.innerHTML = setting.skill;
+                    const user = row.insertCell(1);
+                    user.innerHTML = setting.username;
+                    const key = row.insertCell(2);
+                    key.innerHTML = setting.key;
+                    setupUpdate(row.insertCell(3), row.insertCell(4), `/api/settings/user_setting/${setting.username}/${setting.skill}/${setting.key}`, setting.value, refreshUserSettings);
+                });
+            }
+        });
+    }
+    function refreshUserSettings() {
+        clearTable(document.getElementById("user_settings"));
+        setupUserSettings();
+    }
+    function setupSkillSettings() {
+        request('/api/settings/skill_setting', function (data) {
+            if (data) {
+                data = JSON.parse(data);
+                const table = document.getElementById("skill_settings");
+                data.map(function (setting) {
+                    const row = table.insertRow(-1);
+                    const skill = row.insertCell(0);
+                    skill.innerHTML = setting.skill;
+                    const key = row.insertCell(1);
+                    key.innerHTML = setting.key;
+                    setupUpdate(row.insertCell(2), row.insertCell(3), `/api/settings/skill_setting/${setting.skill}/${setting.key}`, setting.value, refreshSkillSettings);
+                });
+            } else {
+                document.getElementById("skill_settings_div").style.visibility = "hidden";
+            }
+        });
+    }
+    function refreshSkillSettings() {
+        clearTable(document.getElementById("skill_settings"));
+        setupSkillSettings();
+    }
+    function setupGlobalSettings() {
+        request('/api/settings/global_setting', function (data) {
+            if (data) {
+                data = JSON.parse(data);
+                const table = document.getElementById("global_settings");
+                data.map(function (setting) {
+                    const row = table.insertRow(-1);
+                    const key = row.insertCell(0);
+                    key.innerHTML = setting.key;
+                    setupUpdate(row.insertCell(1), row.insertCell(2), `/api/settings/global_setting/${setting.key}`, setting.value, refreshGlobalSettings);
+                });
+            } else {
+                document.getElementById("global_settings_div").style.visibility = "hidden";
+            }
+        });
+    }
+    function refreshGlobalSettings() {
+        clearTable(document.getElementById("global_settings"));
+        setupGlobalSettings();
+    }
+
+    function setupUpdate(element, action, url, value, refresh) {
         const text = document.createElement("INPUT");
         text.setAttribute("type", "text");
-        text.setAttribute("size", length);
+        if (value) {
+            text.setAttribute("size", value.length);
+        }
         text.value = value;
         element.appendChild(text);
+
         const update = document.createElement("INPUT");
         update.setAttribute("type", "submit");
         update.value = "Update";
-        update.onclick = function() {
+        action.appendChild(update);
+
+        const remove = document.createElement("INPUT");
+        remove.setAttribute("type", "submit");
+        remove.value = "Remove";
+        action.appendChild(remove);
+
+        remove.onclick = function () {
+            if (confirm("Are you sure you want to delete this item?")) {
+                update.disabled = true;
+                remove.disabled = true;
+                request(`${url}/remove`, function (data) {
+                    update.disabled = false;
+                    remove.disabled = false;
+                    if (data) {
+                        refresh();
+                        alert("Successfully removed!");
+                    } else {
+                        alert("Removing failed.");
+                    }
+                })
+            }
+        };
+        update.onclick = function () {
             const newValue = encodeURIComponent(JSON.stringify(parseValue(text.value)));
             update.disabled = true;
-            request(`${url}${newValue}`, function (data) {
+            remove.disabled = true;
+            request(`${url}?value=${newValue}`, function (data) {
                 update.disabled = false;
+                remove.disabled = false;
                 if (data) {
-                    update.value = "Update (Success!)";
+                    alert("Update success!");
                 } else {
-                    update.value = "Update (Failure)";
+                    alert("Update failed.");
                 }
             })
         };
-
-        element.appendChild(update);
     }
 
-    function getLongestSetting(data) {
-        let longestSetting = 20;
-        data.map(function (setting) {
-            if (setting.value) {
-                if (setting.value.length > longestSetting) {
-                    longestSetting = setting.value.length;
-                }
-            }
-        });
-        return longestSetting;
-    }
-
-    request('/api/settings/user_setting', function(data) {
-        if (data) {
-            data = JSON.parse(data);
-            const table = document.getElementById("user_settings");
-            const length = getLongestSetting(data);
-            data.map(function (setting) {
-                const row = table.insertRow(-1);
-                const skill = row.insertCell(0);
-                skill.innerHTML = setting.skill;
-                const user = row.insertCell(1);
-                user.innerHTML = setting.username;
-                const key = row.insertCell(2);
-                key.innerHTML = setting.key;
-                setupUpdate(row.insertCell(3), `/api/settings/user_setting/${setting.username}/${setting.skill}/${setting.key}?value=`, setting.value, length);
-            });
-        }
-    });
-    request('/api/settings/skill_setting', function(data) {
-        if (data) {
-            data = JSON.parse(data);
-            const table = document.getElementById("skill_settings");
-            const length = getLongestSetting(data);
-            data.map(function (setting) {
-                const row = table.insertRow(-1);
-                const skill = row.insertCell(0);
-                skill.innerHTML = setting.skill;
-                const key = row.insertCell(1);
-                key.innerHTML = setting.key;
-                setupUpdate(row.insertCell(2), `/api/settings/skill_setting/${setting.skill}/${setting.key}?value=`, setting.value, length);
-            });
-        }
-    });
-    request('/api/settings/global_setting', function(data) {
-        if (data) {
-            data = JSON.parse(data);
-            const table = document.getElementById("global_settings");
-            const length = getLongestSetting(data);
-            data.map(function (setting) {
-                const row = table.insertRow(-1);
-                const key = row.insertCell(0);
-                key.innerHTML = setting.key;
-                setupUpdate(row.insertCell(1), `/api/settings/global_setting/${setting.key}?value=`, setting.value, length);
-            });
-        }
-    });
+    setupUserSettings();
+    setupSkillSettings();
+    setupGlobalSettings();
 </script>
 </body>
 </html>

--- a/src/settings.html
+++ b/src/settings.html
@@ -1,0 +1,146 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>P-Brain Settings</title>
+</head>
+<body>
+    <h1>P-Brain Settings</h1>
+    Changing user settings tends to only require a client refresh. Changing skill and global settings tends to require a server restart.
+    <h2>User Settings</h2>
+    <table id="user_settings" border="1">
+        <tr>
+            <th>Skill</th><th>User</th><th>Key</th><th>Value</th>
+        </tr>
+    </table>
+    <h2>Skill Settings</h2>
+    <table id="skill_settings" border="1">
+        <tr>
+            <th>Skill</th><th>Key</th><th>Value</th>
+        </tr>
+    </table>
+    <h2>Global Settings</h2>
+    <table id="global_settings" border="1">
+        <tr>
+            <th>Key</th><th>Value</th>
+        </tr>
+    </table>
+<script>
+    function request(url, callback) {
+        const xhr = new XMLHttpRequest();
+        xhr.onreadystatechange = function() {
+            if (xhr.readyState == XMLHttpRequest.DONE) {
+                if (xhr.status == 200) {
+                    callback(xhr.responseText);
+                } else {
+                    callback(null);
+                }
+            }
+        };
+        xhr.open('GET', url, true);
+        xhr.send();
+    }
+    function parseValue(value) {
+        if (value == 'true') {
+            value = true;
+        } else if (value == 'false') {
+            value = false;
+        } else {
+            const asInt = parseInt(value);
+            if (isNaN(asInt)) {
+                const asFloat = parseFloat(value);
+                if (!isNaN(asFloat)) {
+                    value = asFloat;
+                }
+            } else {
+                value = asInt;
+            }
+        }
+        return value;
+    }
+
+    function setupUpdate(element, url, value, length) {
+        const text = document.createElement("INPUT");
+        text.setAttribute("type", "text");
+        text.setAttribute("size", length);
+        text.value = value;
+        element.appendChild(text);
+        const update = document.createElement("INPUT");
+        update.setAttribute("type", "submit");
+        update.value = "Update";
+        update.onclick = function() {
+            const newValue = encodeURIComponent(JSON.stringify(parseValue(text.value)));
+            update.disabled = true;
+            request(`${url}${newValue}`, function (data) {
+                update.disabled = false;
+                if (data) {
+                    update.value = "Update (Success!)";
+                } else {
+                    update.value = "Update (Failure)";
+                }
+            })
+        };
+
+        element.appendChild(update);
+    }
+
+    function getLongestSetting(data) {
+        let longestSetting = 20;
+        data.map(function (setting) {
+            if (setting.value) {
+                if (setting.value.length > longestSetting) {
+                    longestSetting = setting.value.length;
+                }
+            }
+        });
+        return longestSetting;
+    }
+
+    request('/api/settings/user_setting', function(data) {
+        if (data) {
+            data = JSON.parse(data);
+            const table = document.getElementById("user_settings");
+            const length = getLongestSetting(data);
+            data.map(function (setting) {
+                const row = table.insertRow(-1);
+                const skill = row.insertCell(0);
+                skill.innerHTML = setting.skill;
+                const user = row.insertCell(1);
+                user.innerHTML = setting.username;
+                const key = row.insertCell(2);
+                key.innerHTML = setting.key;
+                setupUpdate(row.insertCell(3), `/api/settings/user_setting/${setting.username}/${setting.skill}/${setting.key}?value=`, setting.value, length);
+            });
+        }
+    });
+    request('/api/settings/skill_setting', function(data) {
+        if (data) {
+            data = JSON.parse(data);
+            const table = document.getElementById("skill_settings");
+            const length = getLongestSetting(data);
+            data.map(function (setting) {
+                const row = table.insertRow(-1);
+                const skill = row.insertCell(0);
+                skill.innerHTML = setting.skill;
+                const key = row.insertCell(1);
+                key.innerHTML = setting.key;
+                setupUpdate(row.insertCell(2), `/api/settings/skill_setting/${setting.skill}/${setting.key}?value=`, setting.value, length);
+            });
+        }
+    });
+    request('/api/settings/global_setting', function(data) {
+        if (data) {
+            data = JSON.parse(data);
+            const table = document.getElementById("global_settings");
+            const length = getLongestSetting(data);
+            data.map(function (setting) {
+                const row = table.insertRow(-1);
+                const key = row.insertCell(0);
+                key.innerHTML = setting.key;
+                setupUpdate(row.insertCell(1), `/api/settings/global_setting/${setting.key}?value=`, setting.value, length);
+            });
+        }
+    });
+</script>
+</body>
+</html>


### PR DESCRIPTION
This PR doesn't change any existing API's in a major way. It improves on some but retains backwards compatibility. If you don't raise any objections I'll likely merge this in myself after I've created a web page to manage users. The current settings.html page is aesthetically incredibly basic and could certainly be improved if you're feeling in the mood @patrickjquinn.

Changelist:
- Added warnings on server boot when in promiscuous mode.
- Modified the settings calls to return the settings ordered.
- Added a settings.html which uses the HTTP calls to add/delete/update the various types of settings with support for admin and non-admin users.
- Re-factored the database wrapper to reduce boilerplate code and increase error checking.
- Modified the getUser call in the database to allow finding by username, username and password or user_id.
- Added HTTP API's for adding/updating/deleting users.